### PR TITLE
Add single line comment toggle & more syntax highlighting rules

### DIFF
--- a/Comments.tmPreferences
+++ b/Comments.tmPreferences
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+    <key>name</key>
+    <string>Comments</string>
+    <key>scope</key>
+    <string>source.maude</string>
+    <key>settings</key>
+    <dict>
+        <key>shellVariables</key>
+        <array>
+            <dict>
+                <key>name</key>
+                <string>TM_COMMENT_START</string>
+                <key>value</key>
+                <string>*** </string>
+            </dict>
+
+            <dict>
+                <key>name</key>
+                <string>TM_COMMENT_START_2</string>
+                <key>value</key>
+                <string>--- </string>
+            </dict>
+        <!--
+            <dict>
+                <key>name</key>
+                <string>TM_COMMENT_START_3</string>
+                <key>value</key>
+                <string>***( </string>
+            </dict>
+            <dict>
+                <key>name</key>
+                <string>TM_COMMENT_END_3</string>
+                <key>value</key>
+                <string>)</string>
+            </dict>
+        -->
+        </array>
+    </dict>
+</dict>
+</plist>

--- a/maude.YAML-tmLanguage
+++ b/maude.YAML-tmLanguage
@@ -9,7 +9,7 @@ patterns:
 - name: comment.block
   begin: \*\*\*\(
   end: \)$
-  
+
 - name: comment.line
   match: ((\*\*\*)|(---)).*
 
@@ -23,7 +23,7 @@ patterns:
   match: \b(sort|subsort|sorts|subsorts)\b
 
 - name: keyword.control.statements
-  match: \b(op|ops|var|vars|eq|ceq|rl)\b
+  match: \b(op|ops|var|vars|eq|ceq|rl|crl|cmb|reduce|red|rewrite|rew)\b
 
 - name: storage.type
   match: \b(Bool|Nat|Zero|NzNat|Int|NzInt|Rat|PosRat|NzRat|Float|FiniteFloat|String|Char|Qid|List\{.+\}|NeList\{.+\}|NatList|Bool|Universal)\b

--- a/maude.sublime-syntax
+++ b/maude.sublime-syntax
@@ -19,6 +19,7 @@ contexts:
     - include: constant
     - include: operators
 
+
   strings:
     # Strings begin and end with quotes, and use backslashes as an escape
     # character
@@ -68,9 +69,14 @@ contexts:
       scope: constant.numeric.maude
 
   operators:
-    - match: '(:|(\-\>)|=|\/\\|\<|\>)|(\.\s*$)'
+    - match: '(:|(\-\>)|(\=\>)|\<|\>)|(\.\s*)'
       scope: keyword.operator.maude
 
+    - match: '(\+|\-)'
+      scope: keyword.operator.arithmetic.maude
+
+    - match: '(=[^\/]|\=\/\=|\/\\)'
+      scope: keyword.operator.logical.maude
 
   comments:
     # block comments begin with ***( and end with )
@@ -79,11 +85,7 @@ contexts:
       push: line_block
 
     # single line comments begin with *** or ---
-    - match: '\*\*\*[^\(]'
-      scope: punctuation.definition.comment.line.maude
-      push: line_comment
-
-    - match: '\-\-\-'
+    - match: '(\*\*\*[^\(])|(\-\-\-)'
       scope: punctuation.definition.comment.line.maude
       push: line_comment
 

--- a/maude.sublime-syntax
+++ b/maude.sublime-syntax
@@ -1,0 +1,101 @@
+%YAML 1.2
+---
+# See http://www.sublimetext.com/docs/syntax.html
+name: Maude
+file_extensions: [maude, ]
+scope: source.maude
+
+contexts:
+
+  # The prototype context is prepended to all contexts but those setting
+  # meta_include_prototype: false.
+  prototype:
+    - include: comments
+
+  main:
+    - include: strings
+    - include: keywords
+    - include: storage
+    - include: constant
+    - include: operators
+
+  strings:
+    # Strings begin and end with quotes, and use backslashes as an escape
+    # character
+    - match: '"'
+      scope: punctuation.definition.string.begin.maude
+      push: double_quoted_string
+
+  double_quoted_string:
+    - meta_scope: string.quoted.double.maude
+    - match: '\\.'
+      scope: constant.character.escape.maude
+    - match: '"'
+      scope: punctuation.definition.string.end.maude
+      pop: true
+
+  keywords:
+    # Keywords are if, else for and while.
+    # Note that blackslashes don't need to be escaped within single quoted
+    # strings in YAML. When using single quoted strings, only single quotes
+    # need to be escaped: this is done by using two single quotes next to each
+    # other.
+
+    - match: '\b(mod|fmod|omod|endm|endfm|endm|is)\b'
+      scope: keyword.control.module.maude
+
+    - match: '\b(protecting|including|extending)\b'
+      scope: keyword.control.imports.maude
+
+    - match: '\b(sort|subsort|sorts|subsorts)\b'
+      scope: keyword.control.sorts.maude
+
+    - match: '\b(op|ops|var|vars|eq|ceq|rl|crl|cmb|reduce|red|rewrite|rew)\b'
+      scope: keyword.control.statements.maude
+
+    - match: '\b(if|else|for|while)\b'
+      scope: keyword.control.flow.maude
+
+  storage:
+    - match: '\b(Bool|Nat|Zero|NzNat|Int|NzInt|Rat|PosRat|NzRat|Float|FiniteFloat|String|Char|Qid|List\{.+\}|NeList\{.+\}|NatList|Bool|Universal)\b'
+      scope: storage.type.maude
+
+  constant:
+    - match: '\b(true|false|nil)\b'
+      scope: constant.language.maude
+
+    - match: '\b([0-9]+)\b'
+      scope: constant.numeric.maude
+
+  operators:
+    - match: '(:|(\-\>)|=|\/\\|\<|\>)|(\.\s*$)'
+      scope: keyword.operator.maude
+
+
+  comments:
+    # block comments begin with ***( and end with )
+    - match: '\*\*\*\('
+      scope: punctuation.definition.comment.block.begin.maude
+      push: line_block
+
+    # single line comments begin with *** or ---
+    - match: '\*\*\*[^\(]'
+      scope: punctuation.definition.comment.line.maude
+      push: line_comment
+
+    - match: '\-\-\-'
+      scope: punctuation.definition.comment.line.maude
+      push: line_comment
+
+
+  line_comment:
+    - meta_scope: comment.line.maude
+    - match: '\n'
+      pop: true
+
+  line_block:
+    - meta_scope: comment.block.maude
+    - match: '\s*\)\s*\n'
+      scope: punctuation.definition.comment.end.maude
+      pop: true
+

--- a/maude.sublime-syntax
+++ b/maude.sublime-syntax
@@ -18,7 +18,11 @@ contexts:
     - include: storage
     - include: constant
     - include: operators
+    - include: entity
 
+  entity:
+    - match: '(?<=(rl |crl) \[)\s*([a-zA-Z0-9\-\+\_])+(?=\s*\]\s*:\s*)'
+      scope: entity.name.function.maude
 
   strings:
     # Strings begin and end with quotes, and use backslashes as an escape


### PR DESCRIPTION
Unfortunately I wasn't able to solve the issue of toggling multi line comments.

* can now use Sublime Text default keybind of `Ctrl+/` to toggle comment lines
* added a `maude.sublime-syntax` file
* added a few more control statements (crl, cmb, reduce/red, rewrite/rew) based on the 3.1 manual [available from here](http://maude.cs.illinois.edu/w/index.php/Maude_download_and_installation)

copy of https://github.com/jpsikorra/maude_syntax_highlight/pull/2
